### PR TITLE
Our Project Contributors section made mobile responsive

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -175,13 +175,12 @@
 .contributors-2022 {
     font-family: "poppins", sans-serif;
     height: 400px;
-    width: 600px;
-    margin: 40px 0px;
+    width: 70%;
+    margin: 40px auto;
     background-color: #1d2d44;
     padding: 25px;
     border-radius: 20px;
     box-shadow: 0 0 5px 10px #48abe0;
-    margin-left: 180px;
   }
   .contributors-heading {
     font-size: 2rem;


### PR DESCRIPTION
before 
![6vpo0w](https://user-images.githubusercontent.com/67059525/193873655-fd0769ad-684f-4adc-b25b-82e6e4a92318.gif)
after
![6vpoeb](https://user-images.githubusercontent.com/67059525/193873778-17952eb6-644a-4996-871f-8dd5a2a88255.gif)
